### PR TITLE
Fix the program to run without `panic!` on a completely fresh environment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use serde::{Serialize, Deserialize};
-use crate::io::{file_to_string, file_exists, write_to_file};
+use crate::io::{dir_exists, file_exists, file_to_string, mkdir, write_to_file};
 
 /// The location of the database file. Unchangeable: the user doesn't need to know the location of
 /// this file
@@ -34,6 +34,9 @@ impl ConfigOptions
 /// Given a path, expand environment variables and tilde at beginning if it exists
 fn expand_path(path: &str) -> String
 {
+    if path.chars().count() < 1 {
+        return path.to_string();
+    }
     let result = match path.chars().next().unwrap() {
         '/' => path.to_string(),
         '~' => shellexpand::tilde(path).to_string(),
@@ -50,20 +53,26 @@ impl ConfigOptions
         let xdg_cfg_dir = option_env!("XDG_CONFIG_HOME");
         let config_path = if xdg_cfg_dir.is_none() {
             // Use $HOME/.config/settle/settle.yaml if XDG_CONFIG_HOME isn't set
-            format!( "{}/.config/settle/settle.yaml", env!("HOME"))
+            format!("{}/.config/settle", env!("HOME"))
         } else {
             // Use $XDG_CONFIG_HOME/settle/settle.yaml otherwise
-            format!( "{}/settle/settle.yaml", xdg_cfg_dir.unwrap())
+            format!("{}/settle", xdg_cfg_dir.unwrap())
         };
+        let config_file = format!("{}/settle.yaml", config_path);
+
+        // If the dir doesn't exist, create it
+        if !dir_exists(&config_path) {
+            mkdir(&config_path);
+        }
 
         // If the file doesn't exist, create it
-        if !file_exists(&config_path) {
+        if !file_exists(&config_file) {
             let data = serde_yaml::to_string(&ConfigOptions::default()).unwrap();
-            write_to_file(&config_path, &data);
+            write_to_file(&config_file, &data);
         }
 
         // The paths inside the config file may not be absolute, and so we need to expand them
-        let tmp: ConfigOptions = serde_yaml::from_str(&file_to_string(&config_path)).unwrap();
+        let tmp: ConfigOptions = serde_yaml::from_str(&file_to_string(&config_file)).unwrap();
         ConfigOptions {
             zettelkasten: expand_path(&tmp.zettelkasten),
             template: expand_path(&tmp.template),

--- a/src/io.rs
+++ b/src/io.rs
@@ -14,6 +14,12 @@ pub fn file_exists(path: &str) -> bool
     Path::new(path).is_file()
 }
 
+/// Return true if the path specified exists and is a dir
+pub fn dir_exists(path: &str) -> bool
+{
+    Path::new(path).is_dir()
+}
+
 /// Return the last segment of a path
 pub fn basename(path: &str) -> String
 {


### PR DESCRIPTION
The problem before these changes:
From a blank install (just learned about this program), just running `settle` causes the binary to panic. At first:

```
thread 'main' panicked at 'Unable to write file: Os { code: 2, kind: NotFound, message: "No such file or directory" }', /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/settle-0.38.0/src/io.rs:34:23
```

line 34 in io.rs calls to line 62 in config.rs:
`write_to_file(&config_path, &data);`

solution: handle the directory first, by having `config_path` refer to the dir, and add `config_file` to refer to the .yaml. Then, add a check to make sure the dir exists, and create it if it doesn't using the already-written `mkdir`.

next problem:
`    let result = match path.chars().next().unwrap() {`

line 31 of config.rs calls `next()` before doing anything on the `&str` - since the default in the code is the empty string "", the subsequent `.unwrap()` causes a panic

solution: not entirely clear; I just added this block to the very front of `expand_path`:
```
    if path.chars().count() < 1 {
        return path.to_string();
    }
```

This change made the program exit cleanly when just invoking it with `cargo run`, but I'm not sure that this is the best solution.

Finally, some of the `use`s have been reordered; my editor setup automatically runs `rustfmt`. I removed a lot of the things this changed to avoid noise, but left the `use` re-orders for lines where I added an import. I do recommend running `rustfmt` across your code automatically somehow, but I'll leave that up to you as the author.